### PR TITLE
zuul: fix doc on keeping a node running after job end

### DIFF
--- a/procedures/zuul.md
+++ b/procedures/zuul.md
@@ -76,13 +76,10 @@ Notes:
     * `ssh zuul-worker@<zuul_node_ip> -i /var/lib/software-factory/bootstrap-data/ssh_keys/zuul_rsa`
 
 ### Keep node running after job end
-* Check the `job_id` from the URL of the job ouput.
-    ex: `https://zuul.wazo.community/zuul/t/local/stream/9eecc3177cbb45d39d9aeb5430146a34?logfile=console.log`
-        The `job_id` is `9eecc3177cbb45d39d9aeb5430146a34`
 * From `root@zuul.wazo.community`
-    * `zuul autohold --tenant local --project wazo-platform/<repository> --job <job_id> --reason fblackburn-debug`
+    * `zuul autohold --tenant local --project wazo-platform/<repository> --job debian-packaging --reason fblackburn-debug`
     * Do what you want to do and delete node after
-    * `nodepool list | grep <zuul_node_ip>`
+    * Find the `node_id` `nodepool list | grep <zuul_node_ip>`
     * `nodepool delete <node_id>`
 
 ### Removing a dandling job


### PR DESCRIPTION
the --job parameter is not the job_id from the log URL but the name of the task
debian-packaging for example